### PR TITLE
Fixing upload of photo organization

### DIFF
--- a/gestorpsi/upload/views.py
+++ b/gestorpsi/upload/views.py
@@ -36,7 +36,7 @@ def send(request):
         if 'file' in request.FILES:
             pathdir = '%s/img/organization/%s' % (MEDIA_ROOT, user.get_profile().org_active.id)
             if not os.path.exists(pathdir):
-                os.mkdir(pathdir)
+                os.makedirs(pathdir)
                 os.mkdir('%s/.thumb' % pathdir)
                 os.mkdir('%s/.thumb-whitebg' % pathdir)
                 os.chmod(pathdir, 0777)


### PR DESCRIPTION
- Pelo o que foi analisado o problema com a foto da organização se deve ao fato do método _mkdir()_ no python não conseguir criar as pastas de forma recursiva. 

- Como a pasta **organization** não existe dentro do caminho **gestorpsi/media/img**, a imagem não é salva. 

- A correção proposta é utilizar o metódo _makedirs()_ que cria as pastas de forma recursiva.  